### PR TITLE
enable fifo sns topic

### DIFF
--- a/infra/lib/anonymizationStack.ts
+++ b/infra/lib/anonymizationStack.ts
@@ -22,10 +22,12 @@ export class MistAnonymizationProxyStack extends cdk.Stack {
     super(scope, id, props);
 
     // * sns
-    // this topic does NOT enforce deduplication
+    // this topic preserves ordering and deduplicates messages based on content
     this.topic = new sns.Topic(this, 'topic', {
-      topicName: 'mist-dwell-proxy-topic',
+      topicName: 'mist-dwell-proxy-topic.fifo',
       displayName: 'Mist Dwell Proxy Topic',
+      fifo: true,
+      contentBasedDeduplication: true
     });
 
     // * proxy

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -166,7 +166,8 @@ export const main = async (
           DataType: 'String',
           StringValue: processedEvent.type
         }
-      }
+      },
+      MessageGroupId: processedEvent.zone_id
     });
 
     // publish


### PR DESCRIPTION
# enable fifo sns topic

this enables `fifo` mode on the sns topic that receives and relays messages, this will help enforce better ordering of incoming messages, and more importantly allows us to enforce 'at most once' delivery of messages
﻿
